### PR TITLE
fix: issue/2 - reading trim of undefined fix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9549,7 +9549,7 @@ const populateTemplate = (str) => {
             throw new Error(`Invalid template key found: ${str}`);
     }
 };
-const lines = pullRequest.body.trim().split('\n');
+const lines = (pullRequest.body || '').trim().split('\n');
 if (top) {
     const topStr = templateKeyRegex.test(top) ? populateTemplate(top) : top;
     if (!!topStr && lines[0] !== topStr)

--- a/index.ts
+++ b/index.ts
@@ -60,7 +60,7 @@ const populateTemplate = (str: string) => {
   }
 }
 
-const lines = pullRequest.body.trim().split('\n');
+const lines = (pullRequest.body || '').trim().split('\n');
 
 if (top) {
   const topStr = templateKeyRegex.test(top) ? populateTemplate(top) : top;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "build": "ncc build index.ts --license licenses.txt"
+  },
   "devDependencies": {
     "@types/node": "18.7.17",
     "@typescript-eslint/eslint-plugin": "5.37.0",


### PR DESCRIPTION
resolves error by providing a default body of an empty string before calling .trim().

Resolves #2 